### PR TITLE
use spacing with background color for show as gridlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # EZCalendar-Swift
 Easy way to generate calendar with SwiftUI
+
+
+### GridLine
+
+Gridline's color can be enable automatically with the color was set.
+
+```swift
+EZCalendarHorizontalPagingView()
+    ....
+    .gridLineColor(.baseNeutral)
+```

--- a/Sources/EZCalendar/Widgets/CalendarHorizontalPagging/EZCalendarHorizontalPagingView.swift
+++ b/Sources/EZCalendar/Widgets/CalendarHorizontalPagging/EZCalendarHorizontalPagingView.swift
@@ -59,6 +59,7 @@ where WeekdayItemView: View, DayItemView: View {
                                     calendar: viewModel.calendar,
                                     dayItemViewContent: dayItemViewContent
                                 )
+                                .gridLineColor(.red)
                             }
                             .id(calendarMonth.uuid)
                         }

--- a/Sources/EZCalendar/Widgets/CalendarHorizontalPagging/EZCalendarHorizontalPagingView.swift
+++ b/Sources/EZCalendar/Widgets/CalendarHorizontalPagging/EZCalendarHorizontalPagingView.swift
@@ -17,6 +17,8 @@ where WeekdayItemView: View, DayItemView: View {
     
     @State var activeCalendarMonthUUID: String? = nil
     
+    var gridLineColor: Color? = nil
+    
     public init(
         currentMonth: Binding<Date>,
         viewModel: StateObject<EZCalendarHorizontalPagingViewModel>,
@@ -59,7 +61,7 @@ where WeekdayItemView: View, DayItemView: View {
                                     calendar: viewModel.calendar,
                                     dayItemViewContent: dayItemViewContent
                                 )
-                                .gridLineColor(.red)
+                                .gridLineColor(self.gridLineColor)
                             }
                             .id(calendarMonth.uuid)
                         }
@@ -95,5 +97,15 @@ where WeekdayItemView: View, DayItemView: View {
         .onAppear{
             activeCalendarMonthUUID = viewModel.getCalendarMonth(fromDate: currentMonth)?.uuid
         }
+    }
+    
+    public func gridLineColor(_ color: Color?) -> Self {
+        guard let color else {
+            return self
+        }
+        
+        var newView = self
+        newView.gridLineColor = color
+        return newView
     }
 }

--- a/Sources/EZCalendar/Widgets/CalendarItem/EZCalendarItemView.swift
+++ b/Sources/EZCalendar/Widgets/CalendarItem/EZCalendarItemView.swift
@@ -12,6 +12,7 @@ public struct EZCalendarItemView<DayItemView>: View where DayItemView: View {
     @ObservedObject var viewModel: EZCalendarItemViewModel
     
     var dayItemViewContent: (CalendarDay) -> DayItemView
+    private var gridLineColor: Color? = nil
     
     public init(
         _ calendarMonth: CalendarMonth,
@@ -34,8 +35,20 @@ public struct EZCalendarItemView<DayItemView>: View where DayItemView: View {
                 dayItemViewContent(calendarDay)
             }
         }
-        .padding(1)
-        .background(.red)
+        
+        if self.gridLineColor == nil {
+            gridView
+        } else {
+            gridView
+                .padding(1)
+                .background(self.gridLineColor)
+        }
+        
     }
     
+    func gridLineColor(_ color: Color) -> Self {
+        var newView = self
+        newView.gridLineColor = color
+        return newView
+    }
 }

--- a/Sources/EZCalendar/Widgets/CalendarItem/EZCalendarItemView.swift
+++ b/Sources/EZCalendar/Widgets/CalendarItem/EZCalendarItemView.swift
@@ -26,13 +26,16 @@ public struct EZCalendarItemView<DayItemView>: View where DayItemView: View {
     }
     
     public var body: some View {
-        let columns = Array(repeating: GridItem(.flexible()), count: 7)
+        let columns = Array(repeating: GridItem(.flexible(), spacing: 1), count: 7)
         let days = viewModel.calendarWeeks.flatMap { $0.calendarDays }
         
-        LazyVGrid(columns: columns) {
+        LazyVGrid(columns: columns, spacing: 1) {
             ForEach(days, id: \.self) { calendarDay in
                 dayItemViewContent(calendarDay)
             }
         }
+        .padding(1)
+        .background(.red)
     }
+    
 }


### PR DESCRIPTION
it's always apply 1pt to be gridline with your passing color.

```swift
EZCalendarHorizontalPagingView()
    ....
    .gridLineColor(.baseNeutral)
```